### PR TITLE
Fix VG `image_id` key

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -165,7 +165,7 @@ def _load_visualgenome(dataroot, name, img_id2val, label2ans, adaptive=True):
         vgv = {}
         for _v in _vgv: 
             if None != _v['coco_id']:
-                vgv[_v['id']] = _v['coco_id']
+                vgv[_v['image_id']] = _v['coco_id']
         counts = [0, 0, 0, 0] # used image, used question, total question, out-of-split
         for vg in vgq:
             coco_id = vgv.get(vg['id'], None)


### PR DESCRIPTION
For #28, the 1.2 version of VG `image_data.json` does not have a key called `id`, but `image_id`. I checked the number of unique samples from `id`s in `question_answers.json` and `image_id` in `image_data.json` to be the same with `108,077`.